### PR TITLE
feat: Add module-level fixtures attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.4.2 (Unreleased)
+
+### Added
+
+- Added module-level fixtures support:
+  - New `#[with_fixtures_module]` attribute to apply fixtures to all test functions in a module
+  - Eliminates the need to add `#[with_fixtures]` to each test function
+  - Supports nested modules with their own fixtures
+  - Documentation in wiki/Fixtures.md
+  - Examples in examples/module_fixtures.rs
+
 ## 0.4.1 (2024-04-13)
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "fluent-test"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "colored",
  "ctor",
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "fluent-test-macros"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluent-test"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 authors = ["Romain Laneuville<romain.laneuville@hotmail.fr>"]
 description = "A fluent, Jest-like testing library for Rust"
@@ -16,7 +16,7 @@ lazy_static = "1.4.0"
 thread_local = "1.1.8"
 once_cell = "1.18.0"
 ctor = "0.2.7"
-fluent-test-macros = { path = "./fluent-test-macros", version = "0.4.1" }
+fluent-test-macros = { path = "./fluent-test-macros", version = "0.4.2" }
 
 [dev-dependencies]
 

--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ fn my_test() {
 
 Key features:
 - Attribute-based API with `#[setup]`, `#[tear_down]`, and `#[with_fixtures]`
+- Module-level fixtures with `#[with_fixtures_module]` to apply fixtures to all tests in a module
 - Module-scoped fixtures (fixtures are tied to the module they're defined in)
 - Automatic cleanup on test failures
 - Multiple setup/teardown functions per module

--- a/examples/module_fixtures.rs
+++ b/examples/module_fixtures.rs
@@ -1,0 +1,82 @@
+use fluent_test::prelude::*;
+use std::cell::RefCell;
+
+// A shared counter for demonstration
+thread_local! {
+    static TEST_COUNTER: RefCell<u32> = RefCell::new(0);
+}
+
+// Helper to increment the counter
+fn increment_counter() {
+    TEST_COUNTER.with(|counter| {
+        *counter.borrow_mut() += 1;
+    });
+}
+
+// Helper to get the counter value
+fn get_counter() -> u32 {
+    return TEST_COUNTER.with(|counter| *counter.borrow());
+}
+
+// Define functions to demonstrate module fixtures
+fn setup_module_fixtures() {
+    println!("\nExample of using module-level fixtures:");
+    println!("In a real test, you would use:");
+    println!("#[with_fixtures_module]");
+    println!("mod my_test_module {{");
+    println!("    #[setup]");
+    println!("    fn setup() {{ /* setup code */ }}");
+    println!("");
+    println!("    #[tear_down]");
+    println!("    fn tear_down() {{ /* cleanup code */ }}");
+    println!("");
+    println!("    #[test]");
+    println!("    fn test_something() {{ /* fixtures automatically applied */ }}");
+    println!("}}\n");
+}
+
+// Module fixture setup example
+fn run_fixture_setup() {
+    println!("Setting up test environment...");
+    TEST_COUNTER.with(|counter| {
+        *counter.borrow_mut() = 0;
+    });
+}
+
+// Module fixture teardown example
+fn run_fixture_teardown() {
+    println!("Cleaning up test environment...");
+    TEST_COUNTER.with(|counter| {
+        println!("Final counter value: {}", *counter.borrow());
+    });
+}
+
+// Simulate a test
+fn run_simulated_test() {
+    // Run a simulated setup
+    run_fixture_setup();
+
+    println!("Running test...");
+    // Test code
+    expect!(get_counter()).to_equal(0);
+
+    // Do something in the test
+    increment_counter();
+    expect!(get_counter()).to_equal(1);
+
+    // Run a simulated teardown
+    run_fixture_teardown();
+}
+
+fn main() {
+    // Enable enhanced output for better test reporting
+    config().enhanced_output(true).apply();
+
+    // Explain the module fixture concept
+    setup_module_fixtures();
+
+    // Run a simulated test
+    run_simulated_test();
+
+    println!("\nAll tests passed!");
+}

--- a/fluent-test-macros/Cargo.toml
+++ b/fluent-test-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluent-test-macros"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 authors = ["Romain Laneuville<romain.laneuville@hotmail.fr>"]
 description = "Procedural macros for fluent-test"
@@ -13,6 +13,6 @@ categories = ["development-tools", "development-tools::testing"]
 proc-macro = true
 
 [dependencies]
-syn = { version = "2.0", features = ["full"] }
+syn = { version = "2.0", features = ["full", "visit-mut"] }
 quote = "1.0"
 proc-macro2 = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@ pub fn auto_initialize_for_tests() {
 pub use config::initialize;
 
 // Export attribute macros for fixtures
-pub use fluent_test_macros::{setup, tear_down, with_fixtures};
+pub use fluent_test_macros::{setup, tear_down, with_fixtures, with_fixtures_module};
 
 /// Matcher traits module for bringing the traits into scope
 pub mod matchers {
@@ -74,7 +74,7 @@ pub mod prelude {
     pub use crate::expect_not;
 
     // Fixture attribute macros
-    pub use crate::{setup, tear_down, with_fixtures};
+    pub use crate::{setup, tear_down, with_fixtures, with_fixtures_module};
 
     // Import all matcher traits
     pub use crate::matchers::*;

--- a/tests/module_fixtures_test.rs
+++ b/tests/module_fixtures_test.rs
@@ -1,0 +1,136 @@
+use fluent_test::prelude::*;
+use std::cell::RefCell;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+// Counters for tracking setup and teardown calls
+static SETUP_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+// Test state shared between tests
+thread_local! {
+    static TEST_VALUE: RefCell<u32> = RefCell::new(0);
+}
+
+// Helper to set the test value
+fn set_test_value(value: u32) {
+    TEST_VALUE.with(|v| {
+        *v.borrow_mut() = value;
+    });
+}
+
+// Helper to get the test value
+fn get_test_value() -> u32 {
+    TEST_VALUE.with(|v| *v.borrow())
+}
+
+// Main test module using module-level fixtures
+#[with_fixtures_module]
+mod module_fixtures {
+    use super::*;
+
+    // Setup function using the attribute style
+    #[setup]
+    fn setup_function() {
+        SETUP_COUNTER.fetch_add(1, Ordering::SeqCst);
+        TEST_VALUE.with(|v| {
+            *v.borrow_mut() = 0;
+        });
+    }
+
+    // Teardown function using the attribute style
+    #[tear_down]
+    fn teardown_function() {
+        expect!(get_test_value()).to_equal(42);
+    }
+
+    // This test should have fixtures applied automatically
+    #[test]
+    fn test_fixtures_are_applied_automatically() {
+        // Setup function should have been called
+        let setup_count = SETUP_COUNTER.load(Ordering::SeqCst);
+        expect!(setup_count).to_be_greater_than(0);
+
+        // Test value should be reset by setup
+        expect!(get_test_value()).to_equal(0);
+
+        // Modify the value
+        set_test_value(42);
+        expect!(get_test_value()).to_equal(42);
+    }
+
+    // This test should also have fixtures applied automatically
+    #[test]
+    fn test_fixtures_run_for_each_test() {
+        // Value should be reset back to 0 for this test
+        expect!(get_test_value()).to_equal(0);
+
+        // Setup should have run again for this test
+        let setup_count = SETUP_COUNTER.load(Ordering::SeqCst);
+        expect!(setup_count).to_be_greater_than(1);
+
+        // Modify the value
+        set_test_value(42);
+        expect!(get_test_value()).to_equal(42);
+    }
+}
+
+// A nested module test case
+mod nested_module_test {
+    use super::*;
+
+    // The outer module has a different setup/teardown
+    #[setup]
+    fn outer_setup() {
+        SETUP_COUNTER.fetch_add(10, Ordering::SeqCst); // Add 10 to differentiate
+        TEST_VALUE.with(|v| {
+            *v.borrow_mut() = 100;
+        });
+    }
+
+    #[tear_down]
+    fn outer_teardown() {
+        expect!(get_test_value()).to_equal(150);
+    }
+
+    // This nested module gets its own fixtures
+    #[with_fixtures_module]
+    mod inner_module {
+        use super::*;
+
+        // Override the setup defined in the outer module
+        #[setup]
+        fn inner_setup() {
+            SETUP_COUNTER.fetch_add(1, Ordering::SeqCst);
+            // Reset to a specific value to verify this setup runs
+            TEST_VALUE.with(|v| {
+                *v.borrow_mut() = 200;
+            });
+        }
+
+        #[tear_down]
+        fn inner_teardown() {
+            // This teardown should check the value set by inner_setup
+            expect!(get_test_value()).to_equal(250);
+        }
+
+        // This test should use the inner module's fixtures
+        #[test]
+        fn test_inner_fixtures_are_applied() {
+            // Test should have the value from the inner setup, not outer setup
+            expect!(get_test_value()).to_equal(200);
+            // Modify the value
+            set_test_value(250);
+            expect!(get_test_value()).to_equal(250);
+        }
+    }
+
+    // Test that uses the outer fixtures but needs explicit annotation
+    #[test]
+    #[with_fixtures]
+    fn test_outer_fixtures_explicit() {
+        // This should use the outer setup, which sets to 100
+        expect!(get_test_value()).to_equal(100);
+        // Modify the value
+        set_test_value(150);
+        expect!(get_test_value()).to_equal(150);
+    }
+}

--- a/wiki/Fixtures.md
+++ b/wiki/Fixtures.md
@@ -9,7 +9,7 @@ FluentTest provides a fixture system that allows you to set up and tear down tes
 
 ## Using Fixtures
 
-Fixtures are defined using attribute macros and are tied to the module they're defined in. Tests that use the `#[with_fixtures]` attribute will automatically run the setup and teardown functions for that module.
+Fixtures are defined using attribute macros and are tied to the module they're defined in. Tests that use the `#[with_fixtures]` attribute will automatically run the setup and teardown functions for that module. You can also apply fixtures to all test functions in a module using the `#[with_fixtures_module]` attribute on the module itself.
 
 ### Basic Example
 
@@ -37,6 +37,46 @@ fn my_test() {
     expect!(2 + 2).to_equal(4);
 }
 ```
+
+## Module-Level Fixtures
+
+You can apply fixtures to all test functions in a module by using the `#[with_fixtures_module]` attribute:
+
+```rust
+use fluent_test::prelude::*;
+
+#[with_fixtures_module]
+mod user_tests {
+    use super::*;
+    
+    #[setup]
+    fn setup() {
+        // Setup specific to user tests
+        println!("Setting up test environment");
+    }
+    
+    #[tear_down]
+    fn tear_down() {
+        // Teardown specific to user tests
+        println!("Cleaning up test environment");
+    }
+    
+    // No need for #[with_fixtures] on each test
+    #[test]
+    fn test_one() {
+        // Fixtures will be automatically applied
+        expect!(2 + 2).to_equal(4);
+    }
+    
+    #[test]
+    fn test_two() {
+        // Fixtures will also be applied here
+        expect!(3 + 3).to_equal(6);
+    }
+}
+```
+
+This eliminates the need to add `#[with_fixtures]` to each test function, making your tests more concise.
 
 ## Module Scoping
 


### PR DESCRIPTION
Adds the #[with_fixtures_module] attribute which can be applied to a module
to automatically apply fixtures to all #[test] functions within it.

- Implemented the module visitor to process test functions
- Added documentation to README.md and wiki/Fixtures.md
- Added example in examples/module_fixtures.rs
- Added tests in tests/module_fixtures_test.rs
- Updated version to 0.4.2
